### PR TITLE
Add rule to check for space after colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Checks:
 + **T004**: missed colon in TODO.
 + **T005**: missed text in TODO.
 + **T006**: write TODO instead of ToDo (use upper case).
-+ **T007**: missed space in TODO.
++ **T007**: missed space after colon in TODO.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Checks:
 + **T004**: missed colon in TODO.
 + **T005**: missed text in TODO.
 + **T006**: write TODO instead of ToDo (use upper case).
++ **T007**: missed space in TODO.
 
 ## Installation
 

--- a/flake8_todos/_rules.py
+++ b/flake8_todos/_rules.py
@@ -234,3 +234,24 @@ class InvalidCaseRule(BaseRule):
                     good=match.group(1).upper(),
                 ),
             )
+
+@register_rule
+class MissedSpaceRule(BaseRule):
+    code = 7
+    text = 'missed space after colon in TODO'
+
+    _rex = REX_ALL_TAGS
+
+    def _check(self, token: Token) -> bool:
+        if token.type != COMMENT:
+            return True
+
+        match = self._rex.search(token.string)
+        if not match:
+            return True
+
+        if ' ' not in token.string:
+            return False
+
+        body = token.string[match.end():].strip()
+        return body[0] == ': ' or '): ' in body

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -58,6 +58,7 @@ def checker(tmp_path: Path, text: str) -> Checker:
         (rules.MissedLinkRule,      False,  '1 # TODO(author): lowercase lol-911'),
         (rules.MissedSpaceRule,     True,   '1 # TODO(author): i have a space'),
         (rules.MissedSpaceRule,     False,  '1 # TODO(author):i need a space'),
+        (rules.MissedSpaceRule,     False,  '1 # TODO(author):no-space'),
     ],
 )
 def test_rules(rule: rules.BaseRule, ok: bool, checker: Checker):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -56,6 +56,8 @@ def checker(tmp_path: Path, text: str) -> Checker:
         (rules.MissedLinkRule,      True,   '1 # TODO no colon EIQ-911'),
         (rules.MissedLinkRule,      False,  '1 # TODO(author): no code or link'),
         (rules.MissedLinkRule,      False,  '1 # TODO(author): lowercase lol-911'),
+        (rules.MissedSpaceRule,     True,   '1 # TODO(author): i have a space'),
+        (rules.MissedSpaceRule,     False,  '1 # TODO(author):i need a space'),
     ],
 )
 def test_rules(rule: rules.BaseRule, ok: bool, checker: Checker):


### PR DESCRIPTION
This PR adds a check to make sure that TODOs have a space after the colon. 

For example: 

**Passing**

`# TODO(author): i have a space`

**Failing**

`# TODO(author):i need a space`

