### PR TITLE
Fix no space rule when no author is present

### DIFF
--- a/flake8_todos/_rules.py
+++ b/flake8_todos/_rules.py
@@ -254,4 +254,4 @@ class MissedSpaceRule(BaseRule):
             return False
 
         body = token.string[match.end():].strip()
-        return body[0] == ': ' or '): ' in body
+        return body[:2] == ': ' or '): ' in body

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -59,6 +59,8 @@ def checker(tmp_path: Path, text: str) -> Checker:
         (rules.MissedSpaceRule,     True,   '1 # TODO(author): i have a space'),
         (rules.MissedSpaceRule,     False,  '1 # TODO(author):i need a space'),
         (rules.MissedSpaceRule,     False,  '1 # TODO(author):no-space'),
+        (rules.MissedSpaceRule,     True,   '1 # TODO: i have a space with no author'),
+        (rules.MissedSpaceRule,     False,  '1 # TODO:i need a space with no author'),
     ],
 )
 def test_rules(rule: rules.BaseRule, ok: bool, checker: Checker):


### PR DESCRIPTION
This PR fixes an issue highlighted @AIGeneratedUsername where a `T007` warning is present when there is a space but no author, for example, when `T002` is disabled.