### PR TITLE
Fixing MissedColonRule zero len issue

### DIFF
--- a/flake8_todos/_rules.py
+++ b/flake8_todos/_rules.py
@@ -179,6 +179,8 @@ class MissedColonRule(BaseRule):
         if ':' not in token.string:
             return False
         body = token.string[match.end():].strip()
+        if len(body) == 0:
+            return False
         return body[0] == ':' or '):' in body
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -61,6 +61,7 @@ def checker(tmp_path: Path, text: str) -> Checker:
         (rules.MissedSpaceRule,     False,  '1 # TODO(author):no-space'),
         (rules.MissedSpaceRule,     True,   '1 # TODO: i have a space with no author'),
         (rules.MissedSpaceRule,     False,  '1 # TODO:i need a space with no author'),
+        (rules.MissedSpaceRule,     False,  '1 # type: ignore[index] #TODO'),
     ],
 )
 def test_rules(rule: rules.BaseRule, ok: bool, checker: Checker) -> None:


### PR DESCRIPTION
In certain situations the comparison in MissedColonRule can be against a zero length string. I've added a fix and a test for such a string.